### PR TITLE
Split PERL_MB_OPT as on Unix

### DIFF
--- a/lib/CPAN/API/BuildPL.pm
+++ b/lib/CPAN/API/BuildPL.pm
@@ -152,7 +152,7 @@ Initial thoughts:
 * PERL_MB_OPT -- provides option as if they were specified on the command
 line to Build.PL or any Build action, but with precedence lower than
 actual command line options .  The string *must* be split on whitespace
-as the shell would and the result prepended to any actual command-line
+as a Unix shell would and the result prepended to any actual command-line
 arguments in {@ARGV}
 
 =end wikidoc


### PR DESCRIPTION
Currently in Module::Build and Module::Build::Tiny we're using platform specific splitting for `PERL_MB_OPT`, which means using [Text::ParseWords](https://metacpan.org/pod/Text::ParseWords) on all platforms except Windows, where a [custom and widely presumed buggy function](https://metacpan.org/source/LEONT/Module-Build-0.4214/lib/Module/Build/Platform/Windows.pm#L200) is used.

There is no need for it to do this (it's not handled by a shell), even MakeMaker isn't doing the same with `PERL_MM_OPT`. `local::lib` isn't doing anything Windows specific either as far as I understand.

Hence, I propose we change the behavior in the spec and in the implementations to using Unix semantics even on Windows, just like `ExtUtils::MakeMaker` is with `PERL_MM_OPT`.