### PR TITLE
Add --config, --extra_compiler_flags and --extra_linker_flags

### DIFF
--- a/lib/CPAN/API/BuildPL.pm
+++ b/lib/CPAN/API/BuildPL.pm
@@ -135,6 +135,8 @@ options.  Options should then be processed "in order".
 All command line arguments are accepted on action, even if they
 only affect one action.
 
+* --config <key>=<value>
+  This override the value of a config (as in C<Config.pm>) entry
 * --destdir <dir>
   This sets the destdir as described in L</INSTALL PATHS>
 * --installdirs <type>

--- a/lib/CPAN/API/BuildPL.pm
+++ b/lib/CPAN/API/BuildPL.pm
@@ -137,6 +137,10 @@ only affect one action.
 
 * --config <key>=<value>
   This override the value of a config (as in C<Config.pm>) entry
+* --extra_compiler_flags <value>
+  This sets extra flags to be passed on to any compilation command.
+* --extra_linker_flags <value>
+  This sets extra flags to be passed on to any linking command.
 * --destdir <dir>
   This sets the destdir as described in L</INSTALL PATHS>
 * --installdirs <type>


### PR DESCRIPTION
This adds a few build options to the spec.

All of these have been supported in Module::Build since forever. `--config` has been supported by Module::Build::Tiny/Dist::Build from the start, while the other are [trivial to add](https://github.com/Perl-Toolchain-Gang/module-build-tiny/pull/37)